### PR TITLE
feat: add import_contract macro and refactor to make clippy happy

### DIFF
--- a/crates/loam-sdk-macro/src/lib.rs
+++ b/crates/loam-sdk-macro/src/lib.rs
@@ -1,20 +1,17 @@
 #![recursion_limit = "128"]
 extern crate proc_macro;
-
-mod riff;
-mod util;
-
-use std::{env, path::PathBuf};
-
 use proc_macro::TokenStream;
+use std::env;
 
+use quote::quote;
 use syn::Item;
 
 mod contract;
+mod riff;
+mod util;
 
 /// Generates a companion Trait which has a default type `Impl`, which implements this trait.
-
-/// ```
+///
 #[proc_macro_attribute]
 pub fn riff(_: TokenStream, item: TokenStream) -> TokenStream {
     let parsed: Item = syn::parse(item).unwrap();
@@ -35,15 +32,41 @@ pub fn lazy(item: TokenStream) -> TokenStream {
         .map_or_else(|e| e.to_compile_error().into(), Into::into)
 }
 
+/// Generates the soroban contract code combining all Riffs
 #[proc_macro]
 pub fn soroban_contract(_: TokenStream) -> TokenStream {
-    let dir = std::path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("Cargo.toml");
-    let deps = loam_build::deps::get_riff_deps(&dir).unwrap();
+    let cargo_file = manifest();
+    let riffs = loam_build::deps::riff(&cargo_file).unwrap();
 
-    let deps = deps
+    let deps = riffs
         .iter()
-        .map(|i| PathBuf::from(i.0.to_string()))
+        .map(|i| i.0.to_path_buf().into_std_path_buf())
         .collect::<Vec<_>>();
 
     contract::generate(&deps).into()
+}
+
+fn manifest() -> std::path::PathBuf {
+    std::path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("Cargo.toml")
+}
+
+/// Generates a contract Client for a given contract.
+/// It is expected that the name should be the same as the published contract or a contract in your current workspace.
+#[proc_macro]
+pub fn import_contract(tokens: TokenStream) -> TokenStream {
+    let cargo_file = manifest();
+    let mut dir = loam_build::get_target_dir(&cargo_file)
+        .unwrap()
+        .join(tokens.to_string());
+    let name = syn::parse::<syn::Ident>(tokens).expect("The input must be a valid identifier");
+    dir.set_extension("wasm");
+    let binding = dir.canonicalize().unwrap();
+    let file = binding.to_str().unwrap();
+    quote! {
+        mod #name {
+            use loam_sdk::soroban_sdk;
+            loam_sdk::soroban_sdk::contractimport!(file = #file);
+        }
+    }
+    .into()
 }

--- a/crates/loam-sdk/src/lib.rs
+++ b/crates/loam-sdk/src/lib.rs
@@ -1,4 +1,4 @@
-pub use loam_sdk_macro::{riff, soroban_contract, IntoKey, Lazy};
+pub use loam_sdk_macro::*;
 
 #[cfg(feature = "loam-soroban-sdk")]
 pub mod soroban_sdk;


### PR DESCRIPTION
This adds the macro `import_contract` macro which will create a `mod` with the same name as the contract dependency and will find the wasm file at `./target/loam/contract.wasm`