### PR TITLE
feat: make `target/loam` default directory and use symbolic linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "serde_json",
  "shlex",
  "strsim",
+ "symlink",
  "thiserror",
  "tokio",
 ]
@@ -2098,6 +2099,12 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"

--- a/crates/loam-cli/Cargo.toml
+++ b/crates/loam-cli/Cargo.toml
@@ -50,6 +50,7 @@ heck = "0.4.1"
 cargo_metadata = "0.15.4"
 pathdiff = "0.2.1"
 shlex = "1.1.0"
+symlink = "0.1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/crates/loam-cli/src/commands/build.rs
+++ b/crates/loam-cli/src/commands/build.rs
@@ -164,7 +164,10 @@ impl Cmd {
                     .join(&self.profile)
                     .join(&file);
                 let out_file_path = out_dir.join(&file);
-                fs::copy(target_file_path, out_file_path).map_err(Error::CopyingWasmFile)?;
+                if !out_file_path.exists() {
+                    symlink::symlink_file(target_file_path, out_file_path)
+                        .map_err(Error::CopyingWasmFile)?;
+                }
             }
         }
 

--- a/crates/loam-cli/src/commands/build.rs
+++ b/crates/loam-cli/src/commands/build.rs
@@ -57,7 +57,7 @@ pub struct Cmd {
     /// If provided, wasm files can be found in the cargo target directory, and
     /// the specified directory.
     ///
-    /// If ommitted, wasm files are written only to the cargo target directory.
+    /// If ommitted, wasm files are written only to `target/loam`.
     #[arg(long)]
     pub out_dir: Option<std::path::PathBuf>,
     /// Print commands to build without executing them
@@ -152,17 +152,19 @@ impl Cmd {
                     return Err(Error::Exit(status));
                 }
 
-                if let Some(out_dir) = &self.out_dir {
-                    fs::create_dir_all(out_dir).map_err(Error::CreatingOutDir)?;
+                let out_dir = self
+                    .out_dir
+                    .clone()
+                    .unwrap_or_else(|| Path::new(target_dir).join("loam"));
 
-                    let file = format!("{}.wasm", p.name.replace('-', "_"));
-                    let target_file_path = Path::new(target_dir)
-                        .join("wasm32-unknown-unknown")
-                        .join(&self.profile)
-                        .join(&file);
-                    let out_file_path = Path::new(out_dir).join(&file);
-                    fs::copy(target_file_path, out_file_path).map_err(Error::CopyingWasmFile)?;
-                }
+                fs::create_dir_all(&out_dir).map_err(Error::CreatingOutDir)?;
+                let file = format!("{}.wasm", p.name.replace('-', "_"));
+                let target_file_path = Path::new(target_dir)
+                    .join("wasm32-unknown-unknown")
+                    .join(&self.profile)
+                    .join(&file);
+                let out_file_path = out_dir.join(&file);
+                fs::copy(target_file_path, out_file_path).map_err(Error::CopyingWasmFile)?;
             }
         }
 


### PR DESCRIPTION
Currently the `loam_sdk::import_contract` macro expects that wasm files should live in `target/loam`. This ensures that in the default case built binaries are placed there. Previously if no out_dir was provided nothing was written (just the output of `cargo build` in target/wasm32-unknown-unknown). 

Now the the default will place binaries in the directory, the copying will become more costly. To solve this the copy has been replaced by creating a cross-platform symbolic link once.