### PR TITLE
Add and edits readmes

### DIFF
--- a/crates/loam-build/README.md
+++ b/crates/loam-build/README.md
@@ -1,0 +1,15 @@
+# Loam-Build
+
+Builds any package in your workspace that is labeled as a loam package. This contains the low level tools **used in loam-cli's build command AND loam-sdk-macro.**
+
+Anything in `test/` is there to test loam build.
+
+Looks through the workspace to find any crates where the `Cargo.toml` file indicates that a contract exists.
+
+Indicating a contract exists is accomplished with this snippet:
+```toml
+[package.metadata.loam]  
+contract = true
+```
+
+Traverses all members within a workspace by looking at dependencies and builds contracts in the correct order.

--- a/crates/loam-cli/README.md
+++ b/crates/loam-cli/README.md
@@ -1,0 +1,30 @@
+# loam-cli
+
+Loam CLI helps a user create, develop, and deplopy a loam project with a frontend. [A template repository example using Astro can be seen here](https://github.com/loambuild/template?tab=readme-ov-file#loam-dev).
+
+As seen in that template, you fill out an `environment.toml` file to describe the network settings, accounts, and contracts for each environment your team builds against. This will be used to get environments to a predictable starting state.
+
+Loam CLI comes with three main commands:
+
+* `loam init` - Generates the loam frontend template
+* `loam dev` - Turns the contracts you depend on (contract dependencies) into frontend packages (NPM dependencies), getting your app to the point where it is ready to build or run with its own dev server. Also monitors `contracts/*` for changes to the environments.
+* `loam build` - Essentially the same as `loam dev` but runs for the production environment identified in `environment.toml` and does not continuously monitor `contracts/*`.
+
+## `loam dev` and `loam build` in Depth
+
+`loam dev` and `loam build` essentially work the same, except that one is for testing and another for production.
+
+### `loam dev`
+`loam dev` accomplishes the following when run:
+* defaults to development environment
+* looks at `environment.toml`, which specifies:
+    * if environment uses local or live network
+    * binds contracts
+    * imports contracts to frontend
+* watches `contracts/*` for any changes
+
+
+### `loam build` Suggestions
+We suggest that each frontend have separate contract dependencies, deployed on separate networks.
+
+So, you should build one version of your frontend for mainnet and host it at the root domain, say, `example.com`. Then build a separate version for testnet and host it at a separate domain, maybe `staging.example.com`.

--- a/crates/loam-sdk-macro/README.md
+++ b/crates/loam-sdk-macro/README.md
@@ -1,0 +1,16 @@
+# loam-sdk-macro
+
+This crate only contains macros. Macros generate the code necessary for a user to implement a Subcontract. Ultimately, this means a user
+only writes a few lines of code to create a Core Subcontract, allowing them to instead focus on other Subcontracts they'd like to create.
+
+These macros implement the key methods of a Core Subcontract, `subcontract`, `into_key`, `lazy`.
+
+`#[subcontract]` is an attribute procedural macro (proc macro) that allows user to get and set an admin. This ability is what creates a Core Subcontract and thus defines the most basic definition of a Subcontract.
+
+`lazy` deserializes keys but only as needed.
+
+`into_key` loads and stores types.
+
+Both `lazy` and `into_key` can be used in your subcontract implementations when appropriate.
+
+See `lib.rs` for the implementations of subcontract, lazy, and into_key.

--- a/crates/loam-sdk/README.md
+++ b/crates/loam-sdk/README.md
@@ -1,0 +1,121 @@
+# loam-sdk
+
+- [Getting Started](#getting-started)
+    - [Installation](#installation)
+    - [Setup](#setup)
+    - [Redeploy](#redeploy)
+- [Subcontracts](#subcontracts)
+    - [Creating Contract Subcontracts](#creating-contract-subcontracts)
+    - [External API](#external-api)
+- [CoreSubcontract](#coreriff)
+-   [Using the Core Subcontract](#using-the-coreriff)
+
+### Installation
+
+To install `just`, run the following command:
+
+```bash
+cargo install just
+```
+
+### Setup
+
+To set up the environment, run:
+
+```bash
+just setup
+```
+
+### Redeploy
+
+To see redeployment in action, use:
+
+```bash
+just redeploy
+```
+
+## Subcontracts
+
+A subcontract is a type that implements the `IntoKey` trait, which is used for lazily loading and storing the type.
+
+### Creating  Subcontracts
+
+Here's an example of how to create a contract riff:
+
+```rust
+#[contracttype]
+#[derive(IntoKey)]
+pub struct Messages(Map<Address, String>);
+```
+
+This generates the following implementation:
+
+```rust
+impl IntoKey for Messages {
+    type Key = IntoVal<Env, RawVal>;
+    fn into_key() -> Self::Key {
+      String::from_slice("messages")
+    }
+```
+
+### External API
+
+You can also create and implement external APIs for contract subcontracts:
+
+```rust
+#[riff]
+pub trait IsPostable {
+    fn messages_get(&self, author: Address) -> Option<String>;
+    fn messages_set(&mut self, author: Address, text: String);
+}
+```
+
+## Core Subcontract
+
+The `Core` trait provides the minimum logic needed for a contract to be redeployable. A contract should be able to be redeployed to another contract that can also be redeployed. Redeployment requires admin status, as it would be undesirable for an account to redeploy the contract without permission.
+
+### Using the CoreSubcontract
+
+To use the core riff, create a `Contract` structure and implement the `Core` for it. The `Contract` will be redeployable and will be able to implement other Subcontracts.
+
+```rust
+use loam_sdk::{soroban_contract, soroban_sdk};
+use loam_sdk_core_riff::{owner::Owner, CoreSubcontract};
+
+pub struct Contract;
+
+impl CoreSubcontract for Contract {
+    type Impl = Admin;
+}
+
+soroban_contract!();
+```
+
+This code generates the following implementation:
+
+```rust
+struct SorobanContract;
+
+#[contractimpl]
+impl SorobanContract {
+     pub fn admin_set(env: Env, admin: Address) {
+        set_env(env);
+        Contract::owner_set(owner);
+    }
+    pub fn admin_get(env: Env) -> Option<Address> {
+        set_env(env);
+        Contract::admin_get()
+    }
+    pub fn redeploy(env: Env, wasm_hash: BytesN<32>) {
+        set_env(env);
+        Contract::redeploy(wasm_hash);
+    }
+    // Subcontract methods would be inserted here.
+    // Contract must implement all Subcontracts and is the proxy for the contract calls.
+    // This is because the Subcontracts have default implementations which call the associated type
+}
+```
+
+By specifying the associated `Impl` type for `Core`, you enable the default `Admin` methods to be used (`admin_set`, `admin_get`, `redeploy`). However, you can also provide a different implementation if needed by replacing `Admin` with a different struct/enum that also implements [IsCore](replace).
+
+Notice that the generated code calls `Contract::redeploy` and other methods. This ensures that the `Contract` type is redeployable, while also allowing for extensions, as `Contract` can overwrite the default methods.

--- a/crates/loam-soroban-sdk/README.md
+++ b/crates/loam-soroban-sdk/README.md
@@ -1,1 +1,3 @@
-# loam-sdk
+# loam-soroban-sdk
+
+Loam wrapper around Soroban SDK. This version of Soroban SDK would allow the use of Loam.

--- a/crates/loam-subcontract-core/CHANGELOG.md
+++ b/crates/loam-subcontract-core/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.5](https://github.com/loambuild/loam-sdk/compare/loam-sdk-core-riff-v0.6.4...loam-sdk-core-riff-v0.6.5) - 2023-09-22
+
+### Added
+- update soroban-sdk ([#29](https://github.com/loambuild/loam-sdk/pull/29))
+
+## [0.6.4](https://github.com/loambuild/loam-sdk/compare/loam-sdk-core-riff-v0.6.3...loam-sdk-core-riff-v0.6.4) - 2023-09-01
+
+### Fixed
+- use versions directly so they get bumped by release ([#24](https://github.com/loambuild/loam-sdk/pull/24))
+
+## [0.6.3](https://github.com/loambuild/loam-sdk/compare/loam-sdk-core-riff-v0.6.2...loam-sdk-core-riff-v0.6.3) - 2023-09-01
+
+### Other
+- release ([#15](https://github.com/loambuild/loam-sdk/pull/15))
+
+## [0.6.2](https://github.com/loambuild/loam-sdk/releases/tag/loam-sdk-core-riff-v0.6.2) - 2023-08-31
+
+### Added
+- add CLI with build command and update soroban-sdk ([#11](https://github.com/loambuild/loam-sdk/pull/11))
+- [**breaking**] get_env -> env, and loam -> riff ([#7](https://github.com/loambuild/loam-sdk/pull/7))
+- soroban_contract macro ([#5](https://github.com/loambuild/loam-sdk/pull/5))
+- loam macro ([#4](https://github.com/loambuild/loam-sdk/pull/4))
+- pin CLI binary ([#2](https://github.com/loambuild/loam-sdk/pull/2))
+- add Ownable, Redeployable ([#1](https://github.com/loambuild/loam-sdk/pull/1))
+
+### Fixed
+- add versions to workspace deps in root Cargo.toml ([#19](https://github.com/loambuild/loam-sdk/pull/19))
+- use actual versions ([#18](https://github.com/loambuild/loam-sdk/pull/18))
+- use correct versions ([#17](https://github.com/loambuild/loam-sdk/pull/17))
+- added description and license for crates
+- Owner's type should to included in the generated XDR ([#9](https://github.com/loambuild/loam-sdk/pull/9))
+
+### Other
+- update README ([#3](https://github.com/loambuild/loam-sdk/pull/3))
+- initial

--- a/crates/loam-subcontract-core/Cargo.toml
+++ b/crates/loam-subcontract-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "loam-subcontract-core"
+version = "0.6.5"
+edition = "2021"
+description = "Core Riff for redeployable contracts"
+license = "Apache-2.0"
+
+
+[dependencies]
+loam-sdk = { path = "../loam-sdk", version = "0.6.6", features = [
+    "loam-soroban-sdk",
+] }
+
+[package.metadata.loam]
+riff = true

--- a/crates/loam-subcontract-core/README.md
+++ b/crates/loam-subcontract-core/README.md
@@ -1,0 +1,5 @@
+# loam-core
+
+Contains the implementation of the Core Subcontract, which gets and sets admin.
+
+To read more about how the core subcontract works, see the repo readme or the readme located in `crates/loam-sdk-macro/`

--- a/crates/loam-subcontract-core/src/lib.rs
+++ b/crates/loam-subcontract-core/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+pub mod owner;
+pub use owner::CoreRiff;

--- a/crates/loam-subcontract-core/src/owner.rs
+++ b/crates/loam-subcontract-core/src/owner.rs
@@ -1,0 +1,65 @@
+use loam_sdk::{
+    riff,
+    soroban_sdk::{self, contracttype, env, symbol_short, Address, BytesN, Lazy, Symbol},
+};
+
+#[contracttype(export = false)]
+#[derive(Default)]
+pub struct Owner(Kind);
+
+fn owner_key() -> Symbol {
+    symbol_short!("OWNER")
+}
+
+impl Lazy for Owner {
+    fn get_lazy() -> Option<Self> {
+        env().storage().instance().get(&owner_key())
+    }
+
+    fn set_lazy(self) {
+        env().storage().instance().set(&owner_key(), &self);
+    }
+}
+
+/// Work around not having `Option` in `contracttype`
+#[contracttype(export = false)]
+#[derive(Default)]
+pub enum Kind {
+    Address(Address),
+    #[default]
+    None,
+}
+
+impl IsCoreRiff for Owner {
+    fn owner_get(&self) -> Option<Address> {
+        match &self.0 {
+            Kind::Address(address) => Some(address.clone()),
+            Kind::None => None,
+        }
+    }
+
+    fn owner_set(&mut self, new_owner: Address) {
+        if let Kind::Address(owner) = &self.0 {
+            owner.require_auth();
+        }
+        self.0 = Kind::Address(new_owner);
+    }
+
+    fn redeploy(&self, wasm_hash: BytesN<32>) {
+        self.owner_get().unwrap().require_auth();
+        env().deployer().update_current_contract_wasm(wasm_hash);
+    }
+}
+
+#[riff]
+pub trait IsCoreRiff {
+    /// Get current owner
+    fn owner_get(&self) -> Option<loam_sdk::soroban_sdk::Address>;
+    /// Transfer ownership if already set.
+    /// Should be called in the same transaction as deploying the contract to ensure that
+    /// a different account doesn't claim ownership
+    fn owner_set(&mut self, new_owner: loam_sdk::soroban_sdk::Address);
+
+    /// Owner can redepoly the contract with given hash.
+    fn redeploy(&self, wasm_hash: loam_sdk::soroban_sdk::BytesN<32>);
+}

--- a/crates/loam-subcontract-ft/CHANGELOG.md
+++ b/crates/loam-subcontract-ft/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.5](https://github.com/loambuild/loam-sdk/compare/loam-sdk-ft-v0.6.4...loam-sdk-ft-v0.6.5) - 2023-09-22
+
+### Added
+- update soroban-sdk ([#29](https://github.com/loambuild/loam-sdk/pull/29))
+
+## [0.6.4](https://github.com/loambuild/loam-sdk/compare/loam-sdk-ft-v0.6.3...loam-sdk-ft-v0.6.4) - 2023-09-01
+
+### Fixed
+- use versions directly so they get bumped by release ([#24](https://github.com/loambuild/loam-sdk/pull/24))
+
+## [0.6.2](https://github.com/loambuild/loam-sdk/releases/tag/loam-sdk-ft-v0.6.2) - 2023-08-31
+
+### Added
+- add CLI with build command and update soroban-sdk ([#11](https://github.com/loambuild/loam-sdk/pull/11))
+- soroban_contract macro ([#5](https://github.com/loambuild/loam-sdk/pull/5))
+
+### Fixed
+- add versions to workspace deps in root Cargo.toml ([#19](https://github.com/loambuild/loam-sdk/pull/19))
+- use actual versions ([#18](https://github.com/loambuild/loam-sdk/pull/18))
+- use correct versions ([#17](https://github.com/loambuild/loam-sdk/pull/17))
+- added description and license for crates
+- remove print in macro; calc example, and cleanup ([#6](https://github.com/loambuild/loam-sdk/pull/6))

--- a/crates/loam-subcontract-ft/Cargo.toml
+++ b/crates/loam-subcontract-ft/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "loam-sdk-ft"
+version = "0.6.5"
+edition = "2021"
+description = "A Riff for a fungible token"
+license = "Apache-2.0"
+
+
+[dependencies]
+loam-sdk = { path = "../loam-sdk", version = "0.6.6", features = [
+    "loam-soroban-sdk",
+] }
+
+[package.metadata.loam]
+riff = true

--- a/crates/loam-subcontract-ft/README.md
+++ b/crates/loam-subcontract-ft/README.md
@@ -1,0 +1,7 @@
+# loam-ft
+
+Contains an example of how to create a Subcontract interface. This example is for fungible tokens.
+
+To find an implementation of the fungible token subcontract see, `examples/soroban/ft/src/ft.rs`. 
+
+Notice that a Core Subcontract must be implemented to use any other Subcontracts, including this fungible tokens. This Core Subcontract, as explained in `path/here`, only requires the admin method to be implemented. 

--- a/crates/loam-subcontract-ft/src/lib.rs
+++ b/crates/loam-subcontract-ft/src/lib.rs
@@ -1,0 +1,99 @@
+#![no_std]
+use loam_sdk::{riff, soroban_sdk::Lazy};
+/// The `IsFungible` trait defines methods for implementing a fungible token on the Soroban blockchain.
+/// Fungible tokens are assets that can be exchanged for one another, like a standard currency.
+#[riff]
+pub trait IsFungible {
+    /// Determines the amount of tokens that one address is allowed to spend on behalf of another address.
+    fn allowance(
+        &self,
+        from: loam_sdk::soroban_sdk::Address,
+        spender: loam_sdk::soroban_sdk::Address,
+    ) -> i128;
+
+    /// Increases the allowance that one address can spend on behalf of another address.
+    fn increase_allowance(
+        &mut self,
+        from: loam_sdk::soroban_sdk::Address,
+        spender: loam_sdk::soroban_sdk::Address,
+        amount: i128,
+    );
+
+    /// Decreases the allowance that one address can spend on behalf of another address.
+    fn decrease_allowance(
+        &mut self,
+        from: loam_sdk::soroban_sdk::Address,
+        spender: loam_sdk::soroban_sdk::Address,
+        amount: i128,
+    );
+
+    /// Returns the balance of tokens held by a specific address.
+    fn balance(&self, id: loam_sdk::soroban_sdk::Address) -> i128;
+
+    /// Returns the spendable balance of tokens for a specific address.
+    fn spendable_balance(&self, id: loam_sdk::soroban_sdk::Address) -> i128;
+
+    /// Checks if a specific address is authorized.
+    fn authorized(&self, id: loam_sdk::soroban_sdk::Address) -> bool;
+
+    /// Transfers tokens from one address to another.
+    fn transfer(
+        &mut self,
+        from: loam_sdk::soroban_sdk::Address,
+        to: loam_sdk::soroban_sdk::Address,
+        amount: i128,
+    );
+
+    /// Transfers tokens from one address to another, with a spender address controlling the transfer.
+    fn transfer_from(
+        &mut self,
+        spender: loam_sdk::soroban_sdk::Address,
+        from: loam_sdk::soroban_sdk::Address,
+        to: loam_sdk::soroban_sdk::Address,
+        amount: i128,
+    );
+
+    /// Burns a specified amount of tokens from a specific address.
+    fn burn(&mut self, from: loam_sdk::soroban_sdk::Address, amount: i128);
+
+    /// Burns a specified amount of tokens from a specific address, with a spender address controlling the burn.
+    fn burn_from(
+        &mut self,
+        spender: loam_sdk::soroban_sdk::Address,
+        from: loam_sdk::soroban_sdk::Address,
+        amount: i128,
+    );
+
+    /// Sets the authorization status of a specific address.
+    fn set_authorized(&mut self, id: loam_sdk::soroban_sdk::Address, authorize: bool);
+
+    /// Mints a specified amount of tokens to a specific address.
+    fn mint(&mut self, to: loam_sdk::soroban_sdk::Address, amount: i128);
+
+    /// Retrieves a specified amount of tokens from a specific address (clawback).
+    fn clawback(&mut self, from: loam_sdk::soroban_sdk::Address, amount: i128);
+
+    /// Sets a new admin address.
+    fn set_admin(&mut self, new_admin: loam_sdk::soroban_sdk::Address);
+
+    /// Returns the number of decimal places the token supports.
+    fn decimals(&self) -> u32;
+
+    /// Returns the name of the token as a byte array.
+    fn name(&self) -> loam_sdk::soroban_sdk::Bytes;
+
+    /// Returns the symbol of the token as a byte array.
+    fn symbol(&self) -> loam_sdk::soroban_sdk::Bytes;
+}
+
+#[riff]
+pub trait IsInitable {
+    /// Initialize ft Riff
+    fn ft_init(
+        &mut self,
+        admin: loam_sdk::soroban_sdk::Address,
+        name: loam_sdk::soroban_sdk::Bytes,
+        symbol: loam_sdk::soroban_sdk::Bytes,
+        decimals: u32,
+    );
+}


### PR DESCRIPTION
Accomplishes several tasks:

- Move the content of the root readme to `crates/loam-sdk/readme.md` 
- Make root readme a reference to the readmes inside of each crate, and describe the overall purpose of the project
- Changes all references from "riff" to "subcontract" and describes subcontracts as "smaller, more flexible building blocks" to create smart contracts.
- Creates readmes in each of the crate directories and describes what the code is doing. Some contain examples or references to examples in certain files or directories.
- Renames `loam-core` and `loam-ft` to `loam-subcontract-core` and `loam-subcontract-ft` to mark that they contain subcontract interfaces.