### PR TITLE
feat: expose alloc feature from soroban-sdk

### DIFF
--- a/crates/loam-sdk/Cargo.toml
+++ b/crates/loam-sdk/Cargo.toml
@@ -19,4 +19,4 @@ loam-soroban-sdk = { path = "../loam-soroban-sdk", version = "0.6.8", optional =
 [features]
 default = ["loam-soroban-sdk"]
 soroban-sdk-testutils = ["loam-soroban-sdk/testutils"]
-alloc = ["loam-soroban-sdk/alloc"]
+soroban-sdk-alloc = ["loam-soroban-sdk/alloc"]

--- a/crates/loam-sdk/Cargo.toml
+++ b/crates/loam-sdk/Cargo.toml
@@ -19,3 +19,4 @@ loam-soroban-sdk = { path = "../loam-soroban-sdk", version = "0.6.8", optional =
 [features]
 default = ["loam-soroban-sdk"]
 soroban-sdk-testutils = ["loam-soroban-sdk/testutils"]
+alloc = ["loam-soroban-sdk/alloc"]

--- a/crates/loam-soroban-sdk/Cargo.toml
+++ b/crates/loam-soroban-sdk/Cargo.toml
@@ -19,3 +19,4 @@ soroban-sdk = { version = "21.0.1-preview.2" }
 [features]
 default = []
 testutils = ["soroban-sdk/testutils"]
+alloc = ["soroban-sdk/alloc"]


### PR DESCRIPTION
Currently downstream projects might need this feature provided by the soroban-sdk.