### PR TITLE
Fix/npm package

### DIFF
--- a/npm/dist/getBinary.js
+++ b/npm/dist/getBinary.js
@@ -1,52 +1,48 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getBinary = exports.GithubUrl = void 0;
-const _1 = require(".");
-const path_1 = require("path");
 const os = require("os");
+const path_1 = require("path");
+const _1 = require(".");
 const { version } = require("../package.json");
 const NAME = "loam";
 function getPlatform() {
-  const type = os.type();
-  const arch = os.arch();
-  let typeDict = {
-    Darwin: "apple-darwin",
-    Linux: "unknown-linux-gnu",
-    Windows_NT: "pc-windows-msvc",
-  };
-  let archDict = {
-    x64: "x86_64",
-    arm64: "aarch64",
-  };
-  //@ts-ignore
-  let rust_type = typeDict[type];
-  //@ts-ignore
-  let rust_arch = archDict[arch];
-  if (rust_type && rust_arch) {
-    return [rust_type, rust_arch];
-  }
-  throw new Error(`Unsupported platform: ${type} ${arch}`);
+    const type = os.type();
+    const arch = os.arch();
+    let typeDict = {
+        Darwin: "apple-darwin",
+        Linux: "unknown-linux-gnu",
+        Windows_NT: "pc-windows-msvc",
+    };
+    let archDict = {
+        x64: "x86_64",
+        arm64: "aarch64",
+    };
+    //@ts-ignore
+    let rust_type = typeDict[type];
+    //@ts-ignore
+    let rust_arch = archDict[arch];
+    if (rust_type && rust_arch) {
+        return [rust_type, rust_arch];
+    }
+    throw new Error(`Unsupported platform: ${type} ${arch}`);
 }
 function GithubUrl() {
-  const [platform, arch] = getPlatform();
-  return `https://github.com/elizabethengelman/loam-sdk/releases/download/v${version}/${NAME}-v${version}-${arch}-${platform}.tar.gz`;
+    const [platform, arch] = getPlatform();
+    return `https://github.com/loambuild/loam-sdk/releases/download/loam-cli-v${version}/loam-cli-v${version}-${arch}-${platform}.tar.gz`;
 }
 exports.GithubUrl = GithubUrl;
 function getBinary(name = NAME) {
-  if (!process.env["LOAM_BIN_PATH"]) {
-    process.env["LOAM_BINARY_PATH"] = (0, path_1.join)(
-      os.homedir(),
-      `.${NAME}`,
-      NAME
-    );
-  }
-
-  // const version = require("./package.json").version;
-  const fromEnv = process.env["LOAM_ARTIFACT_URL"];
-  const urls = [GithubUrl()];
-  if (fromEnv) {
-    urls.unshift(fromEnv);
-  }
-  return _1.Binary.create(name, urls);
+    if (!process.env["LOAM_BIN_PATH"]) {
+        process.env["LOAM_BINARY_PATH"] = (0, path_1.join)(os.homedir(), `.${NAME}`, NAME);
+    }
+    // Will use version after publishing to AWS
+    // const version = require("./package.json").version;
+    const fromEnv = process.env["LOAM_ARTIFACT_URL"];
+    const urls = [GithubUrl()];
+    if (fromEnv) {
+        urls.unshift(fromEnv);
+    }
+    return _1.Binary.create(name, urls);
 }
 exports.getBinary = getBinary;

--- a/npm/dist/index.js
+++ b/npm/dist/index.js
@@ -11,6 +11,7 @@ const url_1 = require("url");
 const util_1 = require("util");
 const utils_1 = require("./utils");
 const pipeline = (0, util_1.promisify)(stream.pipeline);
+// this is based on https://github.com/raendev/raen/blob/main/npm/src/index.ts
 class Binary {
     constructor(name, url, installDir = Binary.DEFAULT_INSTALL_DIR) {
         Object.defineProperty(this, "name", {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loam-cli",
-  "version": "0.1.2",
+  "version": "0.9.4",
   "description": "An npm installation for [loam](https://github.com/loambuild/loam-sdk).",
   "keywords": [],
   "main": "dist/index.js",

--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -1,28 +1,28 @@
-import { Binary } from ".";
-import { join } from "path";
 import * as os from "os";
-const {version} = require("../package.json");
+import { join } from "path";
+import { Binary } from ".";
+const { version } = require("../package.json");
 
-const NAME = "loam"
+const NAME = "loam";
 
 function getPlatform() {
   const type = os.type();
   const arch = os.arch();
   let typeDict = {
-    "Darwin": "apple-darwin",
-    "Linux": "unknown-linux-gnu",
-    "Windows_NT": "pc-windows-msvc"
+    Darwin: "apple-darwin",
+    Linux: "unknown-linux-gnu",
+    Windows_NT: "pc-windows-msvc",
   };
 
   let archDict = {
-    "x64": "x86_64",
-    "arm64": "aarch64"
+    x64: "x86_64",
+    arm64: "aarch64",
   };
 
-  //@ts-ignore 
- let rust_type: string? = typeDict[type];
- //@ts-ignore 
- let rust_arch: string? = archDict[arch];
+  //@ts-ignore
+  let rust_type: string? = typeDict[type];
+  //@ts-ignore
+  let rust_arch: string? = archDict[arch];
 
   if (rust_type && rust_arch) {
     return [rust_type, rust_arch];
@@ -32,16 +32,12 @@ function getPlatform() {
 
 export function GithubUrl(): string {
   const [platform, arch] = getPlatform();
-  return `https://github.com/loambuild/loam-sdk/releases/download/v${version}/${NAME}-v${version}-${arch}-${platform}.tar.gz`;
+  return `https://github.com/loambuild/loam-sdk/releases/download/loam-cli-v${version}/loam-cli-v${version}-${arch}-${platform}.tar.gz`;
 }
 
 export function getBinary(name: string = NAME): Promise<Binary> {
   if (!process.env["LOAM_BIN_PATH"]) {
-    process.env["LOAM_BINARY_PATH"] = join(
-      os.homedir(),
-      `.${NAME}`,
-      NAME
-    );
+    process.env["LOAM_BINARY_PATH"] = join(os.homedir(), `.${NAME}`, NAME);
   }
 
   // Will use version after publishing to AWS


### PR DESCRIPTION
The [npm publish workflow](https://github.com/loambuild/loam-sdk/actions/runs/9620006255) failed for a couple of reasons, which this PR should fix 🤞 
* I needed to re-build and check in the updated `dist` dir - it was still the old version when i was pointing at my own fork for testing.
* The github URL should include "loam-cli" in the version name.
* The npm code expects that the version of the npm package matches the rust cli version, so I've just bumped the npm package to 0.9.4.