### PR TITLE
feat: add `derive_contract` to make it macro more explicit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,5 +47,4 @@ jobs:
     - run: just setup
     - run: just create
     - run: just test
-    - run: just redeploy
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,10 @@ jobs:
     name: test RPC
     runs-on: ubuntu-22.04
     env:
-        SOROBAN_RPC_URL: http://localhost:8000/soroban/rpc
-        SOROBAN_NETWORK_PASSPHRASE: "Standalone Network ; February 2017"
-        SOROBAN_ACCOUNT: default
+        STELLAR_RPC_URL: http://localhost:8000/soroban/rpc
+        STELLAR_NETWORK_PASSPHRASE: "Standalone Network ; February 2017"
+        STELLAR_ACCOUNT: default
+        STELLAR_CONTRACT_ID: core
     services:
       rpc:
         image: stellar/quickstart:v423-testing
@@ -45,7 +46,6 @@ jobs:
     - uses: cargo-bins/cargo-binstall@main
     - run: just setup
     - run: just create
-    - run: cat .env
     - run: just redeploy
     - run: just test
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,6 @@ jobs:
     - uses: cargo-bins/cargo-binstall@main
     - run: just setup
     - run: just create
-    - run: just redeploy
     - run: just test
+    - run: just redeploy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4455,15 +4455,15 @@ dependencies = [
 
 [[package]]
 name = "syn-file-expand"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6181cbea559711c240607c08763542d871f1b8988dd48e4c713e1c674642c63"
+checksum = "7af40d2da901c8c24077520fbf09848d38ddb4856a83d661892007836489fdb0"
 dependencies = [
  "im-rc",
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,9 +232,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitmaps"
@@ -277,7 +277,7 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-named-pipe",
  "hyper-util",
  "hyperlocal-next",
@@ -332,12 +332,6 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -419,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "907d8581360765417f8f2e0e7d602733bbed60156b4465b7617243689ef9b83d"
 
 [[package]]
 name = "cfg-if"
@@ -441,14 +435,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -480,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
@@ -492,18 +486,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.5"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2020fa13af48afc65a9a87335bda648309ab3d154cd03c7ff95b378c7ed39c4"
+checksum = "5b4be9c4c4b1f30b78d8a750e0822b6a6102d97e62061c583a6c1dea2dfb33ae"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -632,7 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -690,29 +684,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -731,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -741,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
@@ -755,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
@@ -883,17 +863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,16 +902,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature 2.1.0",
-]
-
-[[package]]
-name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "signature 1.6.4",
+ "signature",
 ]
 
 [[package]]
@@ -952,40 +912,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.1.0",
+ "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
- "curve25519-dalek 3.2.0",
- "ed25519 1.5.3",
- "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
-dependencies = [
- "curve25519-dalek 4.1.2",
- "ed25519 2.2.3",
- "rand_core 0.6.4",
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
  "serde",
  "sha2 0.10.8",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -999,7 +948,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1094,7 +1043,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1428,7 +1377,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd06203b1a9b33a78c88252a625031b094d9e1b647260070c25b09910c0a804"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bstr",
  "gix-path",
  "libc",
@@ -1454,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367ee9093b0c2b04fd04c5c7c8b6a1082713534eab537597ae343663a518fa99"
+checksum = "9eed6931f21491ee0aeb922751bd7ec97b4b2fe8fbfedcb678e2a2dce5f3b8c0"
 dependencies = [
  "bstr",
  "itoa",
@@ -1549,7 +1498,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a29ad0990cf02c48a7aac76ed0dbddeb5a0d070034b83675cc3bbf937eace4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bstr",
  "gix-features",
  "gix-path",
@@ -1595,7 +1544,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7152181ba8f0a3addc5075dd612cea31fc3e252b29c8be8c45f4892bf87426"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bstr",
  "btoi",
  "filetime",
@@ -1642,7 +1591,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a163adb84149e522e991cbe27250a6e01de56f98cd05b174614ce3f8a4e8b140"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -1737,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23623cf0f475691a6d943f898c4d0b89f5c1a2a64d0f92bce0e0322ee6528783"
+checksum = "ca987128ffb056d732bd545db5db3d8b103d252fbf083c2567bb0796876619a4"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1754,7 +1703,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cbd49750edb26b0a691e5246fc635fa554d344da825cd20fa9ee0da9c1b761f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -1878,7 +1827,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fddc27984a643b20dd03e97790555804f98cf07404e0e552c0ad8133266a79a1"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "gix-path",
  "libc",
  "windows-sys 0.52.0",
@@ -2050,7 +1999,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "ignore",
  "walkdir",
 ]
@@ -2062,7 +2011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -2225,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.2"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3935c160d00ac752e09787e6e6bfc26494c2183cc922f1bc678a60d4733bc2"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -2237,9 +2186,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2261,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2285,7 +2234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2301,7 +2250,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs",
@@ -2316,7 +2265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2324,16 +2273,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2350,7 +2299,7 @@ checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2381,124 +2330,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,14 +2337,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -2539,7 +2368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
  "bitmaps",
- "rand_core 0.6.4",
+ "rand_core",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -2548,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "include_dir"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
 dependencies = [
  "glob",
  "include_dir_macros",
@@ -2558,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "include_dir_macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2688,7 +2517,7 @@ dependencies = [
  "async-trait",
  "beef",
  "futures-util",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "jsonrpsee-types",
  "serde",
  "serde_json",
@@ -2704,7 +2533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f80c17f62c7653ce767e3d7288b793dfec920f97067ceb189ebdd3570f2bc20"
 dependencies = [
  "async-trait",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-rustls",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -2783,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -2805,7 +2634,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -2814,12 +2643,6 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "loam-build"
@@ -2875,6 +2698,8 @@ dependencies = [
  "Inflector",
  "assert_fs",
  "cargo_metadata 0.18.1",
+ "darling",
+ "itertools 0.12.1",
  "loam-build",
  "proc-macro2",
  "quote",
@@ -2917,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchers"
@@ -2943,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
@@ -2964,9 +2789,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -3245,9 +3070,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3276,6 +3101,48 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -3324,12 +3191,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "powerfmt"
@@ -3424,7 +3285,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3434,14 +3295,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -3458,7 +3313,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3472,11 +3327,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -3548,7 +3403,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -3634,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19549741604902eb99a7ed0ee177a0663ee1eda51a29f71401f166e47e77806a"
+checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3645,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9f96e283ec64401f30d3df8ee2aaeb2561f34c824381efa24a35f79bf40ee4"
+checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3658,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c74a686185620830701348de757fd36bef4aa9680fd23c49fc539ddcc1af32"
+checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
 dependencies = [
  "sha2 0.10.8",
  "walkdir",
@@ -3693,7 +3548,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3714,14 +3569,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
  "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki 0.102.5",
  "subtle",
  "zeroize",
 ]
@@ -3765,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3857,7 +3713,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3885,11 +3741,11 @@ dependencies = [
 
 [[package]]
 name = "sep5"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba64dc259185fdb8dfea7ab0418292743251efba80c9b20e88afc83c17b2593"
+checksum = "cec6914e06f503f83e431e1762c82003c5233b1dffb6185e51e4c40dd1c26eaa"
 dependencies = [
- "slip10",
+ "slipped10",
  "stellar-strkey",
  "thiserror",
  "tiny-bip39",
@@ -3982,9 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.1"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+checksum = "e73139bc5ec2d45e6c5fd85be5a46949c1c39a4c18e56915f5eb4c12f975e377"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4000,9 +3856,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.1"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+checksum = "b80d3d6b56b64335c0180e5ffde23b3c5e08c14c585b51a15bd0e95393f46703"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4082,19 +3938,19 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-
-[[package]]
-name = "signature"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest 0.10.7",
- "rand_core 0.6.4",
+ "rand_core",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "sized-chunks"
@@ -4116,12 +3972,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "slip10"
-version = "0.4.3"
+name = "slipped10"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28724a6e6f70b0cb115c580891483da6f3aa99e6a353598303a57f89d23aa6bc"
+checksum = "0a45443e66aa5d96db5e02d17db056e1ca970232a4fe73e1f9bc1816d68f4e98"
 dependencies = [
- "ed25519-dalek 1.0.1",
+ "ed25519-dalek",
  "hmac 0.9.0",
  "sha2 0.9.9",
 ]
@@ -4144,9 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.1.0"
+version = "21.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084aab008009e712c445a9d7eab837a86559a6c2341f30bc4f33e9b258947688"
+checksum = "4aa78f4b1c752f5471b033fe54279ef0617ace342be7be11acc7d90e5677790e"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -4156,9 +4012,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-cli"
-version = "21.0.0"
+version = "21.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72deb599f46d1b45fd7e01975defb37fea2290e1a3713a243d07c4d83f86251"
+checksum = "c577b9099ad9f499c8849490bbeed59fb83ae2fe0f426f4ec505bb8eeaa59f81"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -4172,7 +4028,7 @@ dependencies = [
  "directories",
  "dirs 4.0.0",
  "dotenvy",
- "ed25519-dalek 2.0.0",
+ "ed25519-dalek",
  "ethnum",
  "futures-util",
  "gix",
@@ -4180,7 +4036,7 @@ dependencies = [
  "hex",
  "home",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-tls",
  "itertools 0.10.5",
  "jsonrpsee-core",
@@ -4188,6 +4044,7 @@ dependencies = [
  "num-bigint",
  "openssl",
  "pathdiff",
+ "phf",
  "rand",
  "regex",
  "rpassword",
@@ -4230,9 +4087,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "21.1.0"
+version = "21.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16ee889fe99d6828bf3ffac00c84382793c31d62682401dbfa3e1b512f0c542"
+checksum = "9acd7dbf8fc4222f62a4f06c5b32c3e097de97f5ff48218c8d77676d3424f363"
 dependencies = [
  "arbitrary",
  "crate-git-revision 0.0.6",
@@ -4249,9 +4106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "21.1.0"
+version = "21.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e591a15e488e66d3edd4be044fc4ffea438945f022c27129e933275744666f"
+checksum = "558a69d53d543a4b1ac60681332594dc1417080cffd2a6851bb6e0a376ebc76f"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -4259,14 +4116,14 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "21.1.0"
+version = "21.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b73f48ae8081ecfb6c0d56c67f139c52cb6d5b6800d5e1adb9eef8e14a155b9"
+checksum = "956beee1e959b7b8ac7bea8396454d1534927276830430bf015eafdc756d84ae"
 dependencies = [
  "backtrace",
- "curve25519-dalek 4.1.2",
+ "curve25519-dalek",
  "ecdsa",
- "ed25519-dalek 2.0.0",
+ "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
  "getrandom",
@@ -4292,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "21.1.0"
+version = "21.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d0581e3aba14892ee0ce63788f3d3e5d9eb1ab18906a9b7c66d77dae9e9fea"
+checksum = "e04b96c8cf73c941ca134eefd00aa5085c4bcae5d534dd3937f4d69b401a838b"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -4307,9 +4164,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.1.0-rc.1"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d02fc89d3a0e49776cdc35609719ddc5635ff61751b37d5577a06cc4b592ea"
+checksum = "79e99e474b9faf76142348780651b0129747d004818447a71c44325152d3ec71"
 dependencies = [
  "serde",
  "serde_json",
@@ -4321,14 +4178,14 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.1.0-rc.1"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1460cfdb31c0a1a7b93a35573fb9f794244a196224f8bf94cd235e4d29d8563d"
+checksum = "056d762146fba4d5c0798920484f0120526b3e019b021e6efff6ad7dd62cdcbb"
 dependencies = [
  "arbitrary",
  "bytes-lit",
  "ctor",
- "ed25519-dalek 2.0.0",
+ "ed25519-dalek",
  "rand",
  "serde",
  "serde_json",
@@ -4341,9 +4198,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.1.0-rc.1"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a164fe430678986174b9872c6f82c23d73e74d3c6820800979af19c455c0bb70"
+checksum = "8b7d4d78936704cc2e686e1bb77fb5e9075adc392756aea74a3eb47aab74dd7e"
 dependencies = [
  "crate-git-revision 0.0.6",
  "darling",
@@ -4361,9 +4218,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.1.0-rc.1"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eeac587846418ecb0c73e9b05a9719559bccfc05da941d328eb3f8f8664c11a"
+checksum = "b5c72bb3677167ba79c8f0f307b3a5b6469c40fd3ff01599298b3eff5c3f6e19"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -4373,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-json"
-version = "21.0.0"
+version = "21.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a656d37c2e9831bf6da7d022675fe3b3cb88d466c43e5e481648b5a51f982f7a"
+checksum = "3dc10d8c2b492a2397cbada868ab9662a35b946bed7eab5ccd4815741676f132"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4388,9 +4245,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.1.0-rc.1"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c179749d655418a01d6d46d5dd08c024ed2e6ee68689430144195ba2f42ca8"
+checksum = "9c6ca7570c91f2a54120269e6a7edb2f968b1661c54d0faca40b0f727fbc24b7"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4404,9 +4261,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-tools"
-version = "21.0.0"
+version = "21.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5436b45ea9c2efaf6a6bf263e670b66eca1e40bcb5320cadab9c7a7685bd788b"
+checksum = "3d9cfdae646e8e5d49810c3fe3918f0677b90d7546452cc4cee08bc8e4f00e92"
 dependencies = [
  "base64 0.21.7",
  "ethnum",
@@ -4423,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-typescript"
-version = "21.0.0"
+version = "21.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086cde1ef27fc9d23562dcb32803ce96792779f98309627a1807155522c8653d"
+checksum = "5b92aab95fea91ab945ee19a7a6bf261d293e86f1bda999ce048d67b734f512f"
 dependencies = [
  "base64 0.21.7",
  "heck 0.4.1",
@@ -4469,12 +4326,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -4570,9 +4421,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symlink"
@@ -4621,17 +4472,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
 
 [[package]]
 name = "system-configuration"
@@ -4780,20 +4620,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4896,7 +4726,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.14",
+ "toml_edit 0.22.15",
 ]
 
 [[package]]
@@ -4921,9 +4751,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.14"
+version = "0.22.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -5065,6 +4895,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5099,45 +4935,32 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.7"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
+checksum = "72139d247e5f97a3eff96229a7ae85ead5328a39efe76f8bf5a06313d505b6ea"
 dependencies = [
  "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
- "rustls 0.22.4",
+ "rustls 0.23.11",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.26.2",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -5337,9 +5160,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5394,7 +5217,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5421,7 +5244,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5456,18 +5279,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -5484,9 +5307,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5502,9 +5325,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5520,15 +5343,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5544,9 +5367,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5562,9 +5385,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5580,9 +5403,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5598,9 +5421,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -5631,63 +5454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5701,28 +5467,6 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/loam-build/src/deps.rs
+++ b/crates/loam-build/src/deps.rs
@@ -218,7 +218,7 @@ pub fn loam(manifest_path: &Path, kind: &DepKind) -> Result<Vec<(Utf8PathBuf, Pa
 /// - The manifest file cannot be read or parsed.
 /// - There are issues accessing or processing dependency information.
 /// - Any other error occurs during the dependency resolution process.
-pub fn subcontract(manifest_path: &Path) -> Result<Vec<(Utf8PathBuf, PathBuf)>, Error> {
+pub fn subcontract_paths(manifest_path: &Path) -> Result<Vec<(Utf8PathBuf, PathBuf)>, Error> {
     loam(manifest_path, &DepKind::Subcontract)
 }
 
@@ -245,6 +245,32 @@ pub fn contract(manifest_path: &Path) -> Result<Vec<Package>, Error> {
     Ok(all(manifest_path)?
         .into_iter()
         .filter(|p| p.is_dep(&DepKind::Contract) && p.manifest_path != manifest_path)
+        .collect())
+}
+
+/// Retrieves a list of subcontract dependencies for a given manifest path.
+///
+/// This function filters all dependencies of the package specified by the manifest path,
+/// returning only those that are of the Contract kind and are not the package itself.
+///
+/// # Arguments
+///
+/// * `manifest_path` - A Path to the Cargo.toml manifest file.
+///
+/// # Returns
+///
+/// A Result containing a Vec of Package structs representing the contract dependencies,
+/// or an Error if the operation fails.
+///
+/// # Errors
+///
+/// This function will return an Error if:
+/// * There's an issue reading or parsing the manifest file.
+/// * There's a problem retrieving the dependencies.
+pub fn subcontract(manifest_path: &Path) -> Result<Vec<Package>, Error> {
+    Ok(all(manifest_path)?
+        .into_iter()
+        .filter(|p| p.is_dep(&DepKind::Subcontract) && p.manifest_path != manifest_path)
         .collect())
 }
 
@@ -301,7 +327,7 @@ mod tests {
         println!("{normal:#?}{}", normal.name);
         let deps = all(&manifest_path).unwrap();
         println!("{deps:#?}\n{}", deps.len());
-        let deps = subcontract(&manifest_path).unwrap();
+        let deps = subcontract_paths(&manifest_path).unwrap();
         println!("{deps:#?}\n{}", deps.len());
     }
 }

--- a/crates/loam-build/src/deps.rs
+++ b/crates/loam-build/src/deps.rs
@@ -113,7 +113,8 @@ pub fn all(manifest_path: &Path) -> Result<Vec<Package>, Error> {
     let parent = manifest_path
         .parent()
         .ok_or_else(|| Error::ParentNotFound(manifest_path.to_path_buf()))?;
-    let output = Command::new("cargo")
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let output = Command::new(cargo)
         .current_dir(parent)
         .args(["tree", "--prefix", "none", "--edges", "normal"])
         .output()

--- a/crates/loam-cli/tests/it/build_clients/accounts.rs
+++ b/crates/loam-cli/tests/it/build_clients/accounts.rs
@@ -21,7 +21,7 @@ accounts = [
         // check that they're actually funded
         let stderr = env
             .soroban("keys")
-            .args(&[
+            .args([
                 "fund",
                 "alice",
                 "--network-passphrase",

--- a/crates/loam-cli/tests/it/build_clients/contracts.rs
+++ b/crates/loam-cli/tests/it/build_clients/contracts.rs
@@ -45,10 +45,10 @@ network-passphrase = "Standalone Network ; February 2017"
 
         // check that contracts are actually deployed, bound, and imported
         for contract in contracts {
-            assert!(env.cwd.join(format!("packages/{}", contract)).exists());
+            assert!(env.cwd.join(format!("packages/{contract}")).exists());
             assert!(env
                 .cwd
-                .join(format!("src/contracts/{}.ts", contract))
+                .join(format!("src/contracts/{contract}.ts"))
                 .exists());
         }
     });

--- a/crates/loam-cli/tests/it/build_clients/dev.rs
+++ b/crates/loam-cli/tests/it/build_clients/dev.rs
@@ -36,7 +36,7 @@ async fn dev_command_watches_for_changes_and_environments_toml() {
             // Wait for the dev process to detect changes and rebuild
             wait_for_output(
                 &mut stderr_lines,
-                &format!("File changed: {:?}", file_changed_path),
+                &format!("File changed: {file_changed_path:?}"),
             )
             .await;
 

--- a/crates/loam-cli/tests/it/build_clients/dev.rs
+++ b/crates/loam-cli/tests/it/build_clients/dev.rs
@@ -136,7 +136,7 @@ async fn wait_for_output<
     let result = timeout(timeout_duration, async {
         while let Some(line) = lines.next().await {
             let line = line.expect("Failed to read line");
-            println!("{}", line);
+            println!("{line}");
             if line.contains(expected) {
                 return;
             }
@@ -145,9 +145,9 @@ async fn wait_for_output<
     })
     .await;
     match result {
-        Ok(_) => {
-            println!("Found string {}", expected)
+        Ok(()) => {
+            println!("Found string {expected}");
         }
-        Err(_) => panic!("Timed out waiting for output: {}", expected),
+        _ => panic!("Timed out waiting for output: {expected}"),
     }
 }

--- a/crates/loam-cli/tests/it/build_clients/network.rs
+++ b/crates/loam-cli/tests/it/build_clients/network.rs
@@ -25,7 +25,7 @@ fn run_named_network() {
     TestEnv::from("soroban-init-boilerplate", |env| {
         // create a network named "lol"
         env.soroban("network")
-            .args(&[
+            .args([
                 "add",
                 "lol",
                 "--rpc-url",

--- a/crates/loam-cli/tests/it/util.rs
+++ b/crates/loam-cli/tests/it/util.rs
@@ -74,13 +74,14 @@ impl TestEnv {
         loam
     }
 
-    fn cargo_bin_loam(&self) -> PathBuf {
+    fn cargo_bin_loam() -> PathBuf {
         PathBuf::from(env!("CARGO_BIN_EXE_loam"))
     }
 
     pub fn loam_process(&self, cmd: &str) -> ProcessCommand {
-        println!("{}", self.cargo_bin_loam().display());
-        let mut loam = ProcessCommand::new(self.cargo_bin_loam());
+        let bin = Self::cargo_bin_loam();
+        println!("{}", bin.display());
+        let mut loam = ProcessCommand::new(bin);
         loam.current_dir(&self.cwd);
         loam.arg(cmd);
         loam

--- a/crates/loam-sdk-macro/Cargo.toml
+++ b/crates/loam-sdk-macro/Cargo.toml
@@ -16,7 +16,7 @@ syn = { version = "2", features = ["full", "fold", "extra-traits", "visit"] }
 quote = "1.0"
 Inflector = { version = "0.11.4", default-features = false, features = [] }
 thiserror = { workspace = true }
-syn-file-expand = "0.2.0"
+syn-file-expand = "0.3.0"
 cargo_metadata = { workspace = true }
 darling = "0.20.8"
 itertools = "0.12.1"

--- a/crates/loam-sdk-macro/Cargo.toml
+++ b/crates/loam-sdk-macro/Cargo.toml
@@ -18,6 +18,8 @@ Inflector = { version = "0.11.4", default-features = false, features = [] }
 thiserror = { workspace = true }
 syn-file-expand = "0.2.0"
 cargo_metadata = { workspace = true }
+darling = "0.20.8"
+itertools = "0.12.1"
 
 [dev-dependencies]
 assert_fs = "1.0.13"

--- a/crates/loam-sdk-macro/src/contract.rs
+++ b/crates/loam-sdk-macro/src/contract.rs
@@ -28,6 +28,6 @@ pub fn generate(contract: &Ident, methods: &[&TokenStream]) -> TokenStream {
     }
 }
 
-pub fn generate_boilerplate(name: syn::Ident, methods: &[&TokenStream]) -> TokenStream {
-    generate(&name, methods)
+pub fn generate_boilerplate(name: &syn::Ident, methods: &[&TokenStream]) -> TokenStream {
+    generate(name, methods)
 }

--- a/crates/loam-sdk-macro/src/contract.rs
+++ b/crates/loam-sdk-macro/src/contract.rs
@@ -1,9 +1,6 @@
-use std::path::PathBuf;
-
 use proc_macro2::TokenStream;
 use quote::quote;
-
-use crate::util::{self, generate_soroban};
+use syn::Ident;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -18,20 +15,19 @@ impl From<Error> for TokenStream {
     }
 }
 
-/// Find all subcontract deps then use `syn_file_expand` to generate the needed functions from each dep
-pub fn generate(paths: &[PathBuf]) -> TokenStream {
-    let methods = paths
-        .iter()
-        .filter_map(|path| {
-            let file = util::parse_crate_as_file(path)?;
-            Some(generate_soroban(&file))
-        })
-        .collect::<Vec<_>>();
+/// Find all riff deps then use `syn_file_expand` to generate the needed functions from each dep
+pub fn generate(contract: &Ident, methods: &[&TokenStream]) -> TokenStream {
     quote! {
-    #[loam_sdk::soroban_sdk::contract(crate_path = "loam_sdk::soroban_sdk")]
-    pub struct SorobanContract;
-    #[loam_sdk::soroban_sdk::contractimpl(crate_path = "loam_sdk::soroban_sdk")]
-    impl SorobanContract {
-            #(#methods)*
-    }}
+        struct #contract;
+        #[loam_sdk::soroban_sdk::contract(crate_path = "loam_sdk::soroban_sdk")]
+        struct SorobanContract__;
+        #[loam_sdk::soroban_sdk::contractimpl(crate_path = "loam_sdk::soroban_sdk")]
+        impl SorobanContract__ {
+                #(#methods)*
+        }
+    }
+}
+
+pub fn generate_boilerplate(name: syn::Ident, methods: &[&TokenStream]) -> TokenStream {
+    generate(&name, methods)
 }

--- a/crates/loam-sdk-macro/src/lib.rs
+++ b/crates/loam-sdk-macro/src/lib.rs
@@ -101,28 +101,3 @@ pub fn derive_contract(args: TokenStream, item: TokenStream) -> TokenStream {
     let parsed: Item = syn::parse(item.clone()).expect("failed to parse Item");
     derive_contract_impl(proc_macro2::TokenStream::from(args), parsed).into()
 }
-
-// fn find_deps() -> Vec<proc_macro2::TokenStream> {
-//     let cargo_file = manifest();
-//     loam_build::deps::contract(&cargo_file)
-//         .unwrap()
-//         .iter()
-//         .map(|i| i.manifest_path.as_std_path())
-//         .filter_map(|path| {
-//             let file = util::parse_crate_as_file(path)?;
-//             generate_soroban(&quote::format_ident!("Core"), &file)
-//         })
-//         .collect::<Vec<_>>()
-// }
-
-
-// #[test]
-// fn test_deriveC_contract() {
-//     let input: Item = syn::parse_quote! {
-//         #[loam_sdk::derive_contract(Core(Admin), Calc(Calculator))]
-//         pub struct Contract;
-//     };
-    
-//     println!("{input:#?}");
-    
-// }

--- a/crates/loam-sdk-macro/src/lib.rs
+++ b/crates/loam-sdk-macro/src/lib.rs
@@ -98,7 +98,7 @@ pub fn import_contract(tokens: TokenStream) -> TokenStream {
 /// }
 ///
 /// ```
-/// 
+///
 /// # Panics
 /// This function may panic if the input tokens cannot be parsed as a valid Rust item.
 ///

--- a/crates/loam-sdk-macro/src/lib.rs
+++ b/crates/loam-sdk-macro/src/lib.rs
@@ -81,7 +81,7 @@ pub fn import_contract(tokens: TokenStream) -> TokenStream {
 /// pub struct Contract;
 /// ```
 /// Generates
-/// 
+///
 /// ```ignore
 /// pub struct Contract;
 /// impl Postable for Contract {

--- a/crates/loam-sdk-macro/src/lib.rs
+++ b/crates/loam-sdk-macro/src/lib.rs
@@ -40,7 +40,10 @@ pub fn lazy(item: TokenStream) -> TokenStream {
 }
 
 pub(crate) fn manifest() -> std::path::PathBuf {
-    std::path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("failed to finde cargo manifest")).join("Cargo.toml")
+    std::path::PathBuf::from(
+        env::var("CARGO_MANIFEST_DIR").expect("failed to finde cargo manifest"),
+    )
+    .join("Cargo.toml")
 }
 
 /// Generates a contract Client for a given contract.

--- a/crates/loam-sdk-macro/src/lib.rs
+++ b/crates/loam-sdk-macro/src/lib.rs
@@ -97,8 +97,11 @@ pub fn import_contract(tokens: TokenStream) -> TokenStream {
 ///  // Postable and Core methods exposed
 /// }
 ///
-///
 /// ```
+/// 
+/// # Panics
+/// This function may panic if the input tokens cannot be parsed as a valid Rust item.
+///
 #[proc_macro_attribute]
 pub fn derive_contract(args: TokenStream, item: TokenStream) -> TokenStream {
     let parsed: Item = syn::parse(item.clone()).expect("failed to parse Item");

--- a/crates/loam-sdk-macro/src/lib.rs
+++ b/crates/loam-sdk-macro/src/lib.rs
@@ -76,11 +76,12 @@ pub fn import_contract(tokens: TokenStream) -> TokenStream {
 }
 
 /// Generates a contract made up of subcontracts
-/// ```no_run
+/// ```ignore
 /// #[derive_contract(Core(Admin), Postable(StatusMessage))]
 /// pub struct Contract;
 /// ```
 /// Generates
+/// 
 /// ```ignore
 /// pub struct Contract;
 /// impl Postable for Contract {

--- a/crates/loam-sdk-macro/src/lib.rs
+++ b/crates/loam-sdk-macro/src/lib.rs
@@ -81,7 +81,7 @@ pub fn import_contract(tokens: TokenStream) -> TokenStream {
 /// pub struct Contract;
 /// ```
 /// Generates
-/// ```no_run
+/// ```ignore
 /// pub struct Contract;
 /// impl Postable for Contract {
 ///     type Impl = StatusMessage;

--- a/crates/loam-sdk-macro/src/subcontract.rs
+++ b/crates/loam-sdk-macro/src/subcontract.rs
@@ -199,7 +199,7 @@ pub fn derive_contract_impl(args: TokenStream, trait_impls: Item) -> TokenStream
             }
         });
     }
-    let outer_impl = contract::generate_boilerplate(strukt.ident.clone(), &methods);
+    let outer_impl = contract::generate_boilerplate(&strukt.ident, &methods);
     quote! {
         #outer_impl
         #impls

--- a/crates/loam-sdk/README.md
+++ b/crates/loam-sdk/README.md
@@ -55,19 +55,15 @@ The `Core` trait provides the minimum logic needed for a contract to be redeploy
 
 ## Using  `Core`
 
-To use the core subcontract, create a `Contract` struct and implement `Core` for it. This makes `Contract` redeployable by the Admin of the contract and will continue to be redeployable if the new contract also implements `Core`. After `Core` other Subcontracts can be added as needed.
+To use the core subcontract, create a `Contract` struct and implement `Core` with the `Admin` implementation, which ensures the contract is redeployable and will continue to be redeployable if the new contract also implements `Core`. After `Core` other Subcontracts can be added as needed.
 
 ```rust
-use loam_sdk::{soroban_contract, soroban_sdk};
+use loam_sdk::derive_contract;
 use loam_subcontract_core::{Admin, Core};
 
+#[derive_contract(Core(Admin))]
 pub struct Contract;
 
-impl Core for Contract {
-    type Impl = Admin;
-}
-
-soroban_contract!();
 ```
 
 This code generates the following implementation:
@@ -95,6 +91,6 @@ impl SorobanContract {
 }
 ```
 
-By specifying the associated `Impl` type for `Core`, you enable the default `Admin` methods to be used (`admin_set`, `admin_get`, `redeploy`). However, you can also provide a different implementation if needed by replacing `Admin` with a different struct/enum that also implements [IsCore](replace).
+By specifying the associated a concrete implementation for `Core`, `Admin`, you enable its methods to be used (`admin_set`, `admin_get`, `redeploy`). However, you can also provide a different implementation if needed by replacing `Admin` with a different struct/enum that also implements [IsCore](replace).
 
-Notice that the generated code calls `Contract::redeploy` and other methods. This ensures that the `Contract` type is redeployable, while also allowing for extensions, as `Contract` can overwrite the default methods.
+Notice that the generated code includes `Contract::redeploy` and other methods. This ensures that the `Contract` type is redeployable, while also allowing for extensions, as different concrete implementation can overwrite the default methods.

--- a/examples/soroban/calculator/src/lib.rs
+++ b/examples/soroban/calculator/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-use loam_sdk::soroban_contract;
 use loam_subcontract_core::{admin::Admin, Core};
 
 pub mod error;
@@ -8,14 +7,5 @@ pub mod subcontract;
 pub use error::Error;
 use subcontract::{Calc, Calculator};
 
+#[loam_sdk::derive_contract(Core(Admin), Calc(Calculator))]
 pub struct Contract;
-
-impl Core for Contract {
-    type Impl = Admin;
-}
-
-impl Calc for Contract {
-    type Impl = Calculator;
-}
-
-soroban_contract!();

--- a/examples/soroban/core/src/lib.rs
+++ b/examples/soroban/core/src/lib.rs
@@ -1,11 +1,6 @@
 #![no_std]
-use loam_sdk::soroban_contract;
+use loam_sdk::derive_contract;
 use loam_subcontract_core::{admin::Admin, Core};
 
+#[derive_contract(Core(Admin))]
 pub struct Contract;
-
-impl Core for Contract {
-    type Impl = Admin;
-}
-
-soroban_contract!();

--- a/examples/soroban/ft/src/lib.rs
+++ b/examples/soroban/ft/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use loam_sdk::soroban_contract;
+use loam_sdk::derive_contract;
 use loam_subcontract_core::{admin::Admin, Core};
 use loam_subcontract_ft::{Fungible, Initable};
 
@@ -7,18 +7,5 @@ pub mod ft;
 
 use ft::MyFungibleToken;
 
+#[derive_contract(Core(Admin), Fungible(MyFungibleToken), Initable(MyFungibleToken))]
 pub struct Contract;
-
-impl Core for Contract {
-    type Impl = Admin;
-}
-
-impl Fungible for Contract {
-    type Impl = MyFungibleToken;
-}
-
-impl Initable for Contract {
-    type Impl = MyFungibleToken;
-}
-
-soroban_contract!();

--- a/examples/soroban/status_message/src/lib.rs
+++ b/examples/soroban/status_message/src/lib.rs
@@ -1,19 +1,10 @@
 #![no_std]
 // // Currently need to import `self` because `contracttype` expects it in the namespace
-use loam_sdk::soroban_contract;
+use loam_sdk::derive_contract;
 use loam_subcontract_core::{admin::Admin, Core};
 
 mod status_message;
 pub use status_message::*;
 
+#[derive_contract(Core(Admin), Postable(StatusMessage))]
 pub struct Contract;
-
-impl Core for Contract {
-    type Impl = Admin;
-}
-
-impl Postable for Contract {
-    type Impl = StatusMessage;
-}
-
-soroban_contract!();

--- a/justfile
+++ b/justfile
@@ -49,6 +49,6 @@ create: build
 redeploy:
     stellar contract invoke -- admin_set --new_admin default
     stellar contract invoke -- --help
-    stellar contract invoke -- redeploy --wasm_hash $(stellar contract install --wasm ./target/loam/example_status_message.wasm)
+    stellar contract invoke -- redeploy --wasm_hash $(just stellar contract install --wasm ./target/loam/example_status_message.wasm)
     stellar contract invoke -- --help
     stellar contract invoke -- --help | grep messages_get || exit 1

--- a/justfile
+++ b/justfile
@@ -47,8 +47,4 @@ create: build
 # # Builds contracts. Deploys core subcontract and then redeploys to status message.
 
 redeploy:
-    stellar contract invoke -- admin_set --new_admin default
-    stellar contract invoke -- --help
-    stellar contract invoke -- redeploy --wasm_hash $(just stellar contract install --wasm ./target/loam/example_status_message.wasm)
-    stellar contract invoke -- --help
-    stellar contract invoke -- --help | grep messages_get || exit 1
+    ./redeploy.sh

--- a/justfile
+++ b/justfile
@@ -14,13 +14,13 @@ loam +args:
     @cargo r -- {{args}}
 
 s +args:
-    @soroban {{args}}
+    @stellar {{args}}
 
-soroban +args:
-    @soroban {{args}}
+stellar +args:
+    @stellar {{args}}
 
 build_contract p:
-    soroban contract build --profile contracts --package {{p}}
+    stellar contract build --profile contracts --package {{p}}
 
 # build contracts
 build:
@@ -39,15 +39,16 @@ test: build build-cli-test-contracts
 
 create: build
     rm -rf .soroban
-    soroban keys generate default
-    just soroban contract deploy --wasm ./target/loam/example_core.wasm | just loam update-env --name SOROBAN_CONTRACT_ID
+    stellar keys generate default
+    just stellar contract deploy --wasm ./target/loam/example_core.wasm --alias core
 
 # # Builds contracts. Deploys core subcontract and then redep
 
 # # Builds contracts. Deploys core subcontract and then redeploys to status message.
 
 redeploy:
-    soroban contract invoke -- admin_set --new_admin default
-    soroban contract invoke -- --help
-    soroban contract invoke -- redeploy --wasm_hash $(soroban contract install --wasm ./target/loam/example_status_message.wasm)
-    soroban contract invoke -- --help | grep messages_get || exit 1
+    stellar contract invoke -- admin_set --new_admin default
+    stellar contract invoke -- --help
+    stellar contract invoke -- redeploy --wasm_hash $(stellar contract install --wasm ./target/loam/example_status_message.wasm)
+    stellar contract invoke -- --help
+    stellar contract invoke -- --help | grep messages_get || exit 1

--- a/redeploy.sh
+++ b/redeploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+PATH=./target/bin:$PATH
+
+stellar contract invoke -- admin_set --new_admin default
+stellar contract invoke -- --help
+WASM=$(stellar contract install --wasm ./target/loam/example_status_message.wasm)
+echo $WASM
+stellar contract invoke -- redeploy --wasm_hash "$WASM"
+stellar contract invoke -- --help
+stellar contract invoke -- --help | grep messages_get || exit 1

--- a/test/dep-normal/src/lib.rs
+++ b/test/dep-normal/src/lib.rs
@@ -1,9 +1,6 @@
 #![no_std]
-use loam_sdk::soroban_contract;
+use loam_sdk::derive_contract;
 use loam_subcontract_core::{admin::Admin, Core};
 
-struct Contract;
-impl Core for Contract {
-    type Impl = Admin;
-}
-soroban_contract!();
+#[derive_contract(Core(Admin))]
+pub struct Contract;

--- a/test/normal-dep/src/lib.rs
+++ b/test/normal-dep/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
-use loam_sdk::soroban_contract;
 use loam_subcontract_core::{admin::Admin, Core};
 
-struct Contract;
-impl Core for Contract {
-    type Impl = Admin;
-}
-soroban_contract!();
+#[loam_sdk::derive_contract(Core(Admin))]
+pub struct Contract;

--- a/test/normal/src/lib.rs
+++ b/test/normal/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
-use loam_sdk::soroban_contract;
 use loam_subcontract_core::{admin::Admin, Core};
 
-struct Contract;
-impl Core for Contract {
-    type Impl = Admin;
-}
-soroban_contract!();
+#[loam_sdk::derive_contract(Core(Admin))]
+pub struct Contract;


### PR DESCRIPTION
```
#[derive_contract(Core(Admin))
struct Contract;
```
This makes it much clearer which subcontract is being used and which implementation it uses.
