### PR TITLE
feat: allow creating new projects with loam init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,6 +2670,7 @@ dependencies = [
  "notify",
  "pathdiff",
  "predicates",
+ "rust-embed",
  "serde",
  "serde_derive",
  "serde_json",

--- a/crates/loam-cli/Cargo.toml
+++ b/crates/loam-cli/Cargo.toml
@@ -55,6 +55,7 @@ symlink = "0.1.0"
 toml = { version = "0.8.12", features = ["parse"] }
 soroban-cli = "21.0.0"
 notify = "5.0"
+rust-embed = { version = "8.2.0", features = ["debug-embed"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/crates/loam-cli/src/commands/init.rs
+++ b/crates/loam-cli/src/commands/init.rs
@@ -1,0 +1,145 @@
+use soroban_cli::commands::contract::init as soroban_init;
+use std::{
+    fs::{copy, create_dir_all, metadata, read_dir, remove_dir_all, Metadata},
+    io,
+    path::Path,
+};
+
+// command line argument parser
+use clap::Parser;
+
+// TO-DO: Store these somewhere else eventually. Sororban uses examples repo.
+const LOAM_EXAMPLES: &str = "../../../../examples/soroban/";
+const FRONTEND_TEMPLATE: &str = "https://github.com/loambuild/frontend";
+
+/// A command to initialize a new project
+#[derive(Parser, Debug, Clone)]
+pub struct Cmd {
+    /// The path to the project must be provided to initialize
+    pub project_path: String,
+}
+
+// TO-DO: import function from stellar init. This is a slightly modified version of the function that does not edit cargo files
+fn copy_example_contracts(from: &Path, to: &Path, contracts: &[String]) -> Result<(), Error> {
+    let project_contracts_path = to.join("contracts");
+    for contract in contracts {
+        println!("ℹ️  Initializing example contract: {contract}");
+        let contract_as_string = contract.to_string();
+        let contract_path = Path::new(&contract_as_string);
+        let from_contract_path = from.join(contract_path);
+        let to_contract_path = project_contracts_path.join(contract_path);
+        create_dir_all(&to_contract_path).map_err(|e| {
+            eprintln!("Error creating directory: {contract_path:?}");
+            e
+        })?;
+
+        copy_contents(&from_contract_path, &to_contract_path)?;
+    }
+
+    Ok(())
+}
+
+// TO-DO: imported from stellar init. Removes code that adds to gitignore and readme
+fn copy_contents(from: &Path, to: &Path) -> Result<(), Error> {
+    for entry in read_dir(from).map_err(|e| {
+        eprintln!("Error reading directory: {from:?}");
+        e
+    })? {
+        let entry = entry.map_err(|e| {
+            eprintln!("Error reading entry in directory: {from:?}");
+            e
+        })?;
+        let path = entry.path();
+        let entry_name = entry.file_name().to_string_lossy().to_string();
+        let new_path = to.join(&entry_name);
+
+        if path.is_dir() {
+            create_dir_all(&new_path).map_err(|e| {
+                eprintln!("Error creating directory: {new_path:?}");
+                e
+            })?;
+            copy_contents(&path, &new_path)?;
+        } else {
+            if file_exists(&new_path) {
+                println!(
+                    "ℹ️  Skipped creating {} as it already exists",
+                    &new_path.to_string_lossy()
+                );
+                continue;
+            }
+
+            println!("➕  Writing {}", &new_path.to_string_lossy());
+            copy(&path, &new_path).map_err(|e| {
+                eprintln!(
+                    "Error copying from {:?} to {:?}",
+                    path.to_string_lossy(),
+                    new_path.to_string_lossy()
+                );
+                e
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+// TO-DO: imported from stellar init
+fn file_exists(file_path: &Path) -> bool {
+    metadata(file_path)
+        .as_ref()
+        .map(Metadata::is_file)
+        .unwrap_or(false)
+}
+
+/// Errors that can occur during initialization
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Io error: {0}")]
+    IoError(#[from] io::Error),
+    #[error("Soroban init error: {0}")]
+    SorobanInitError(#[from] soroban_init::Error),
+}
+
+impl Cmd {
+    /// Run the initialization command by calling the soroban init command
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// /// From the command line
+    /// loam init /path/to/project
+    /// ```
+    #[allow(clippy::unused_self)]
+    pub fn run(&self) -> Result<(), Error> {
+        let mut examples: Vec<String> = vec![];
+
+        // Create a new project using the soroban init command
+        // by default uses a provided frontend template
+        // Examples cannot currently be added by user
+        soroban_init::Cmd {
+            project_path: self.project_path.clone(),
+            with_example: examples.clone(),
+            frontend_template: FRONTEND_TEMPLATE.to_string(),
+        }
+        .run()?;
+
+        // remove soroban hello_world default contract
+        remove_dir_all(Path::new(&self.project_path.clone()).join("contracts/hello_world/"))
+            .map_err(|e| {
+                eprintln!("Error removing directory");
+                e
+            })?;
+
+        // core and status_message are default examples
+        examples.push("core".to_string());
+        examples.push("status_message".to_string());
+
+        copy_example_contracts(
+            Path::new(LOAM_EXAMPLES),
+            Path::new(&self.project_path.clone()),
+            &examples,
+        )?;
+
+        Ok(())
+    }
+}

--- a/crates/loam-cli/src/commands/init.rs
+++ b/crates/loam-cli/src/commands/init.rs
@@ -1,16 +1,21 @@
+use clap::Parser;
+use rust_embed::{EmbeddedFile, RustEmbed};
 use soroban_cli::commands::contract::init as soroban_init;
 use std::{
-    fs::{copy, create_dir_all, metadata, read_dir, remove_dir_all, Metadata},
+    fs::{create_dir_all, metadata, remove_dir_all, write, Metadata},
     io,
     path::Path,
 };
 
-// command line argument parser
-use clap::Parser;
-
-// TO-DO: Store these somewhere else eventually. Sororban uses examples repo.
-const LOAM_EXAMPLES: &str = "../../../../examples/soroban/";
 const FRONTEND_TEMPLATE: &str = "https://github.com/loambuild/frontend";
+
+#[derive(RustEmbed)]
+#[folder = "../../examples/soroban/core"]
+struct ExampleCore;
+
+#[derive(RustEmbed)]
+#[folder = "../../examples/soroban/status_message"]
+struct ExampleStatusMessage;
 
 /// A command to initialize a new project
 #[derive(Parser, Debug, Clone)]
@@ -18,79 +23,6 @@ pub struct Cmd {
     /// The path to the project must be provided to initialize
     pub project_path: String,
 }
-
-// TO-DO: import function from stellar init. This is a slightly modified version of the function that does not edit cargo files
-fn copy_example_contracts(from: &Path, to: &Path, contracts: &[String]) -> Result<(), Error> {
-    let project_contracts_path = to.join("contracts");
-    for contract in contracts {
-        println!("ℹ️  Initializing example contract: {contract}");
-        let contract_as_string = contract.to_string();
-        let contract_path = Path::new(&contract_as_string);
-        let from_contract_path = from.join(contract_path);
-        let to_contract_path = project_contracts_path.join(contract_path);
-        create_dir_all(&to_contract_path).map_err(|e| {
-            eprintln!("Error creating directory: {contract_path:?}");
-            e
-        })?;
-
-        copy_contents(&from_contract_path, &to_contract_path)?;
-    }
-
-    Ok(())
-}
-
-// TO-DO: imported from stellar init. Removes code that adds to gitignore and readme
-fn copy_contents(from: &Path, to: &Path) -> Result<(), Error> {
-    for entry in read_dir(from).map_err(|e| {
-        eprintln!("Error reading directory: {from:?}");
-        e
-    })? {
-        let entry = entry.map_err(|e| {
-            eprintln!("Error reading entry in directory: {from:?}");
-            e
-        })?;
-        let path = entry.path();
-        let entry_name = entry.file_name().to_string_lossy().to_string();
-        let new_path = to.join(&entry_name);
-
-        if path.is_dir() {
-            create_dir_all(&new_path).map_err(|e| {
-                eprintln!("Error creating directory: {new_path:?}");
-                e
-            })?;
-            copy_contents(&path, &new_path)?;
-        } else {
-            if file_exists(&new_path) {
-                println!(
-                    "ℹ️  Skipped creating {} as it already exists",
-                    &new_path.to_string_lossy()
-                );
-                continue;
-            }
-
-            println!("➕  Writing {}", &new_path.to_string_lossy());
-            copy(&path, &new_path).map_err(|e| {
-                eprintln!(
-                    "Error copying from {:?} to {:?}",
-                    path.to_string_lossy(),
-                    new_path.to_string_lossy()
-                );
-                e
-            })?;
-        }
-    }
-
-    Ok(())
-}
-
-// TO-DO: imported from stellar init
-fn file_exists(file_path: &Path) -> bool {
-    metadata(file_path)
-        .as_ref()
-        .map(Metadata::is_file)
-        .unwrap_or(false)
-}
-
 /// Errors that can occur during initialization
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -98,6 +30,8 @@ pub enum Error {
     IoError(#[from] io::Error),
     #[error("Soroban init error: {0}")]
     SorobanInitError(#[from] soroban_init::Error),
+    #[error("Failed to convert bytes to string: {0}")]
+    ConverBytesToStringErr(#[from] std::str::Utf8Error),
 }
 
 impl Cmd {
@@ -111,14 +45,12 @@ impl Cmd {
     /// ```
     #[allow(clippy::unused_self)]
     pub fn run(&self) -> Result<(), Error> {
-        let mut examples: Vec<String> = vec![];
-
         // Create a new project using the soroban init command
         // by default uses a provided frontend template
         // Examples cannot currently be added by user
         soroban_init::Cmd {
             project_path: self.project_path.clone(),
-            with_example: examples.clone(),
+            with_example: vec![],
             frontend_template: FRONTEND_TEMPLATE.to_string(),
         }
         .run()?;
@@ -130,16 +62,71 @@ impl Cmd {
                 e
             })?;
 
-        // core and status_message are default examples
-        examples.push("core".to_string());
-        examples.push("status_message".to_string());
-
-        copy_example_contracts(
-            Path::new(LOAM_EXAMPLES),
-            Path::new(&self.project_path.clone()),
-            &examples,
-        )?;
+        copy_example_contracts(Path::new(&self.project_path.clone()))?;
 
         Ok(())
     }
+}
+
+fn copy_example_contracts(to: &Path) -> Result<(), Error> {
+    for item in ExampleCore::iter() {
+        copy_file(
+            &to.join("contracts/core"),
+            item.as_ref(),
+            ExampleCore::get(&item),
+        )?;
+    }
+    for item in ExampleStatusMessage::iter() {
+        copy_file(
+            &to.join("contracts/status_message"),
+            item.as_ref(),
+            ExampleStatusMessage::get(&item),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn copy_file(
+    example_path: &Path,
+    filename: &str,
+    embedded_file: Option<EmbeddedFile>,
+) -> Result<(), Error> {
+    let to = example_path.join(filename);
+    if file_exists(&to) {
+        println!(
+            "ℹ️  Skipped creating {} as it already exists",
+            &to.to_string_lossy()
+        );
+        return Ok(());
+    }
+    create_dir_all(to.parent().expect("invalid path")).map_err(|e| {
+        eprintln!("Error creating directory path for: {to:?}");
+        e
+    })?;
+
+    let Some(embedded_file) = embedded_file else {
+        println!("⚠️  Failed to read file: {filename}");
+        return Ok(());
+    };
+
+    let file_contents = std::str::from_utf8(embedded_file.data.as_ref()).map_err(|e| {
+        eprintln!("Error converting file contents in {filename:?} to string",);
+        e
+    })?;
+
+    println!("➕  Writing {}", &to.to_string_lossy());
+    write(&to, file_contents).map_err(|e| {
+        eprintln!("Error writing file: {to:?}");
+        e
+    })?;
+    Ok(())
+}
+
+// TODO: import from stellar-cli init (not currently pub there)
+fn file_exists(file_path: &Path) -> bool {
+    metadata(file_path)
+        .as_ref()
+        .map(Metadata::is_file)
+        .unwrap_or(false)
 }

--- a/crates/loam-cli/src/commands/mod.rs
+++ b/crates/loam-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ use clap::{command, CommandFactory, FromArgMatches, Parser};
 
 pub mod build;
 pub mod dev;
+pub mod init;
 pub mod update_env;
 
 const ABOUT: &str = "Build contracts and generate front ends";
@@ -38,6 +39,7 @@ impl Root {
     }
     pub async fn run(&mut self) -> Result<(), Error> {
         match &mut self.cmd {
+            Cmd::Init(init_info) => init_info.run()?,
             Cmd::Build(build_info) => build_info.run().await?,
             Cmd::UpdateEnv(e) => e.run()?,
             Cmd::Dev(dev_info) => dev_info.run().await?,
@@ -56,6 +58,9 @@ impl FromStr for Root {
 
 #[derive(Parser, Debug)]
 pub enum Cmd {
+    /// Initialize the project
+    Init(init::Cmd),
+
     /// Build contracts, resolving Loam dependencies in the correct order. If you have an `environments.toml` file, it will also follow its instructions to configure the environment set by the `LOAM_ENV` environment variable, turning your contracts into frontend packages (NPM dependencies).
     Build(build::Cmd),
 
@@ -69,6 +74,8 @@ pub enum Cmd {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     // TODO: stop using Debug for displaying errors
+    #[error(transparent)]
+    Init(#[from] init::Error),
     #[error(transparent)]
     BuildContracts(#[from] build::Error),
     #[error(transparent)]


### PR DESCRIPTION
- wraps stellar contract init
- uses copied and modified funtions from stellar contract init to initialize frontend with examples
- however, does not allow `--with-examples` option
- removes hello_world soroban contract created by default with stellar cli