### PR TITLE
fix(CLI): loam dev clone Arc of build command instead of cloning each time

### DIFF
--- a/crates/loam-cli/src/commands/dev/mod.rs
+++ b/crates/loam-cli/src/commands/dev/mod.rs
@@ -185,7 +185,7 @@ impl Cmd {
             tokio::select! {
                 _ = rx.recv() => {
                     let mut state = rebuild_state_clone.lock().await;
-                    let build_command_inner = self.cloned_build_command();
+                    let build_command_inner = build_command.clone();
                     if !*state {
                         *state= true;
                         tokio::spawn(Self::debounced_rebuild(build_command_inner, Arc::clone(&rebuild_state_clone)));


### PR DESCRIPTION
This makes use of `Arc`, so that just the pointer is cloned and reference count incremented instead of cloning the whole build command each time.