### PR TITLE
fix(CLI): core example: rm `loam-soroban-sdk` dep

### DIFF
--- a/crates/loam-cli/src/examples/soroban/core/Cargo.toml.remove
+++ b/crates/loam-cli/src/examples/soroban/core/Cargo.toml.remove
@@ -14,7 +14,6 @@ doctest = false
 [dependencies]
 loam-sdk = { workspace = true, features = ["loam-soroban-sdk"] }
 loam-subcontract-core = { workspace = true }
-loam-soroban-sdk = { workspace = true }
 
 
 [dev_dependencies]


### PR DESCRIPTION
`loam-soroban-sdk` is re-exported from `loam-sdk`. This example imports it from `loam-sdk`. That's the pattern we should encourage, and we should not require projects to specify `loam-soroban-sdk` in their root Cargo.toml in addition to `loam-sdk`.