### PR TITLE
fix(subcontract-core): doc typo "redepoly"

### DIFF
--- a/crates/loam-subcontract-core/src/admin.rs
+++ b/crates/loam-subcontract-core/src/admin.rs
@@ -60,6 +60,6 @@ pub trait IsCore {
     /// a different account try to become admin
     fn admin_set(&mut self, new_admin: loam_sdk::soroban_sdk::Address);
 
-    /// Admin can redepoly the contract with given hash.
+    /// Admin can redeploy the contract with given hash.
     fn redeploy(&self, wasm_hash: loam_sdk::soroban_sdk::BytesN<32>);
 }


### PR DESCRIPTION
it's a fun typo, but still worth fixing